### PR TITLE
Tools for standalone application of electron energy scale

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h
@@ -15,6 +15,8 @@ class ElectronEnergyCalibratorRun2 {
   // dummy constructor for persistence
   ElectronEnergyCalibratorRun2() {}
   
+  // constructor w/o combinator: do not combine E-p: intented for residual corrections
+  ElectronEnergyCalibratorRun2(bool isMC, bool synchronization, std::string); 
   // further configuration will be added when we will learn how it will work
   ElectronEnergyCalibratorRun2(EpCombinationTool &combinator, bool isMC, bool synchronization, std::string); 
   ~ElectronEnergyCalibratorRun2() ;
@@ -41,6 +43,7 @@ class ElectronEnergyCalibratorRun2 {
   /// or from the CMSSW RandomNumberGenerator service
   /// If synchronization is set to true, it returns a fixed number (1.0)
   double gauss(edm::StreamID const& id) const ;
+  bool doEpCombination_;
   EnergyScaleCorrection_class _correctionRetriever;
 };
 

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h
@@ -32,7 +32,7 @@ class ElectronEnergyCalibratorRun2 {
   /// Correct this electron. 
   /// StreamID is needed when used with CMSSW Random Number Generator
   void calibrate(reco::GsfElectron &electron, unsigned int runNumber, edm::StreamID const & id = edm::StreamID::invalidStreamID()) const ;
-  
+
  protected:    
   // whatever data will be needed
   EpCombinationTool *epCombinationTool_;

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2Standalone.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2Standalone.h
@@ -1,0 +1,39 @@
+#ifndef ElectronEnergyCalibratorRun2Standalone_h
+#define ElectronEnergyCalibratorRun2Standalone_h
+
+#include <TRandom.h>
+#include "EgammaAnalysis/ElectronTools/interface/EnergyScaleCorrection_class.hh"
+#include "EgammaAnalysis/ElectronTools/interface/SimpleElectronStandalone.h"
+
+#include <vector>
+
+class ElectronEnergyCalibratorRun2Standalone {
+ public:
+  // dummy constructor for persistence
+  ElectronEnergyCalibratorRun2Standalone() {}
+  
+  // constructor w/o combinator: do not combine E-p: intented for residual corrections
+  ElectronEnergyCalibratorRun2Standalone(bool isMC, bool synchronization, std::string); 
+  ~ElectronEnergyCalibratorRun2Standalone() ;
+  
+  /// Initialize with a random number generator (if not done, it will use the CMSSW service)
+  /// Caller code owns the TRandom.
+  void initPrivateRng(TRandom *rnd) ;
+  
+  /// Correct this electron. 
+  void calibrate(SimpleElectron &electron) const ;
+  
+ protected:    
+  // whatever data will be needed
+  bool isMC_, synchronization_;
+  TRandom *rng_;
+  
+  /// Return a number distributed as a unit gaussian, drawn from the private RNG if initPrivateRng was called, 
+  /// or from the CMSSW RandomNumberGenerator service
+  /// If synchronization is set to true, it returns a fixed number (1.0)
+  double gauss() const ;
+  bool doEpCombination_;
+  EnergyScaleCorrection_class _correctionRetriever;
+};
+
+#endif

--- a/EgammaAnalysis/ElectronTools/interface/SimpleElectronStandalone.h
+++ b/EgammaAnalysis/ElectronTools/interface/SimpleElectronStandalone.h
@@ -1,10 +1,6 @@
 #ifndef SimpleElectron_H
 #define SimpleElectron_H
 
-#ifndef SimpleElectron_STANDALONE
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"        
-#endif
-
 class SimpleElectron
 {
 	public:
@@ -47,11 +43,6 @@ class SimpleElectron
                         scale_(1.0), smearing_(0.0)
         {}
 	    ~SimpleElectron(){}	
-
-#ifndef SimpleElectron_STANDALONE
-        explicit SimpleElectron(const reco::GsfElectron &in, unsigned int runNumber, bool isMC) ;
-        void writeTo(reco::GsfElectron & out) const ;
-#endif
 
     	//accessors
     	double getNewEnergy() const {return newEnergy_;}

--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2.cc
@@ -56,16 +56,22 @@ void ElectronEnergyCalibratorRun2::calibrate(reco::GsfElectron &electron, unsign
   calibrate(simple, id);
   simple.writeTo(electron);
 }
+
 void ElectronEnergyCalibratorRun2::calibrate(SimpleElectron &electron, edm::StreamID const & id) const 
 {
+  std::cout << "calibrating" << std::endl;
   assert(isMC_ == electron.isMC());
+  std::cout << "isMC = " << electron.isMC() << std::endl;
   float smear = 0.0, scale = 1.0;
   float aeta = std::abs(electron.getEta()); //, r9 = electron.getR9();
   float et = electron.getNewEnergy()/cosh(aeta);
   
+  std::cout << "getting scale" << std::endl;
   scale = _correctionRetriever.ScaleCorrection(electron.getRunNumber(), electron.isEB(), electron.getR9(), aeta, et);
+  std::cout << "scale  = " << scale << std::endl;
   smear = _correctionRetriever.getSmearingSigma(electron.getRunNumber(), electron.isEB(), electron.getR9(), aeta, et, 0., 0.); 
-  
+  std::cout << "cmear  =" << smear << std::endl;
+
   double newEcalEnergy, newEcalEnergyError;
   if (isMC_) {
     double corr = 1.0 + smear * gauss(id);
@@ -77,6 +83,7 @@ void ElectronEnergyCalibratorRun2::calibrate(SimpleElectron &electron, edm::Stre
   }
   electron.setNewEnergy(newEcalEnergy); 
   electron.setNewEnergyError(newEcalEnergyError);
+  std::cout << "doEBcomp = " << doEpCombination_ << std::endl;
   if(doEpCombination_) epCombinationTool_->combine(electron);
 }
 

--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2.cc
@@ -4,6 +4,24 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+ElectronEnergyCalibratorRun2::ElectronEnergyCalibratorRun2(bool isMC, 
+							   bool synchronization, 
+							   std::string correctionFile
+							   ) :
+  isMC_(isMC), synchronization_(synchronization),
+  rng_(0),
+  doEpCombination_(false),
+  _correctionRetriever(correctionFile) // here is opening the files and reading the corrections
+{
+  if(isMC_) {
+    _correctionRetriever.doScale = false; 
+    _correctionRetriever.doSmearings = true;
+  } else {
+    _correctionRetriever.doScale = true; 
+    _correctionRetriever.doSmearings = false;
+  }
+}
+
 ElectronEnergyCalibratorRun2::ElectronEnergyCalibratorRun2(EpCombinationTool &combinator, 
 							   bool isMC, 
 							   bool synchronization, 
@@ -12,6 +30,7 @@ ElectronEnergyCalibratorRun2::ElectronEnergyCalibratorRun2(EpCombinationTool &co
   epCombinationTool_(&combinator),
   isMC_(isMC), synchronization_(synchronization),
   rng_(0),
+  doEpCombination_(true),
   _correctionRetriever(correctionFile) // here is opening the files and reading the corrections
 {
   if(isMC_) {
@@ -58,7 +77,7 @@ void ElectronEnergyCalibratorRun2::calibrate(SimpleElectron &electron, edm::Stre
   }
   electron.setNewEnergy(newEcalEnergy); 
   electron.setNewEnergyError(newEcalEnergyError);
-  epCombinationTool_->combine(electron);
+  if(doEpCombination_) epCombinationTool_->combine(electron);
 }
 
 double ElectronEnergyCalibratorRun2::gauss(edm::StreamID const& id) const 

--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2Standalone.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2Standalone.cc
@@ -1,0 +1,66 @@
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2Standalone.h"
+#include <CLHEP/Random/RandGaussQ.h>
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+ElectronEnergyCalibratorRun2Standalone::ElectronEnergyCalibratorRun2Standalone(bool isMC, 
+							   bool synchronization, 
+							   std::string correctionFile
+							   ) :
+  isMC_(isMC), synchronization_(synchronization),
+  rng_(0),
+  doEpCombination_(false),
+  _correctionRetriever(correctionFile) // here is opening the files and reading the corrections
+{
+  if(isMC_) {
+    _correctionRetriever.doScale = false; 
+    _correctionRetriever.doSmearings = true;
+  } else {
+    _correctionRetriever.doScale = true; 
+    _correctionRetriever.doSmearings = false;
+  }
+}
+
+ElectronEnergyCalibratorRun2Standalone::~ElectronEnergyCalibratorRun2Standalone()
+{}
+
+void ElectronEnergyCalibratorRun2Standalone::initPrivateRng(TRandom *rnd) 
+{
+  rng_ = rnd;   
+}
+
+void ElectronEnergyCalibratorRun2Standalone::calibrate(SimpleElectron &electron) const 
+{
+  assert(isMC_ == electron.isMC());
+  float smear = 0.0, scale = 1.0;
+  float aeta = std::abs(electron.getEta()); //, r9 = electron.getR9();
+  float et = electron.getNewEnergy()/cosh(aeta);
+  
+  scale = _correctionRetriever.ScaleCorrection(electron.getRunNumber(), electron.isEB(), electron.getR9(), aeta, et);
+  smear = _correctionRetriever.getSmearingSigma(electron.getRunNumber(), electron.isEB(), electron.getR9(), aeta, et, 0., 0.); 
+
+  double newEcalEnergy, newEcalEnergyError;
+  if (isMC_) {
+    double corr = 1.0 + smear * gauss();
+    newEcalEnergy      = electron.getNewEnergy() * corr;
+    newEcalEnergyError = std::hypot(electron.getNewEnergyError() * corr, smear * newEcalEnergy);
+  } else {
+    newEcalEnergy      = electron.getNewEnergy() * scale;
+    newEcalEnergyError = std::hypot(electron.getNewEnergyError() * scale, smear * newEcalEnergy);
+  }
+  electron.setNewEnergy(newEcalEnergy); 
+  electron.setNewEnergyError(newEcalEnergyError);
+}
+
+double ElectronEnergyCalibratorRun2Standalone::gauss() const 
+{
+  if (synchronization_) return 1.0;
+  if (rng_) {
+    return rng_->Gaus();
+  } else {
+    std::cout << "ERROR! TRandom not initialized! Returning correction 0" << std::endl;
+    return 0.;
+  }
+}
+

--- a/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
+++ b/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
@@ -160,10 +160,8 @@ void EnergyScaleCorrection_class::ReadFromFile(TString filename)
 #ifdef PEDANTIC_OUTPUT
   std::cout << "[STATUS] Reading energy scale correction  values from file: " << filename << std::endl;
 #endif
-  std::cout << "[STATUS] Reading energy scale correction  values from file: " << filename << std::endl;
 
   //std::ifstream Ccufile(edm::FileInPath(Ccufilename).fullPath().c_str(),std::ios::in);
-  std::cout << "===> " << edm::FileInPath(filename).fullPath().c_str() << std::endl;
   std::ifstream f_in(edm::FileInPath(filename).fullPath().c_str());
 
   if(!f_in.good()) {

--- a/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
+++ b/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
@@ -163,6 +163,7 @@ void EnergyScaleCorrection_class::ReadFromFile(TString filename)
   std::cout << "[STATUS] Reading energy scale correction  values from file: " << filename << std::endl;
 
   //std::ifstream Ccufile(edm::FileInPath(Ccufilename).fullPath().c_str(),std::ios::in);
+  std::cout << "===> " << edm::FileInPath(filename).fullPath().c_str() << std::endl;
   std::ifstream f_in(edm::FileInPath(filename).fullPath().c_str());
 
   if(!f_in.good()) {
@@ -173,19 +174,18 @@ void EnergyScaleCorrection_class::ReadFromFile(TString filename)
   
   int runMin, runMax;
   TString category, region2;
-  double deltaP, err_deltaP, err_deltaP_stat, err_deltaP_syst;
+  double deltaP, err_deltaP, err_deltaP_stat, err_deltaP_syst, err_deltaP_tot;
   
   
   for(f_in >> category; f_in.good(); f_in >> category) {
     f_in >> region2
 	 >> runMin >> runMax
-	 >> deltaP >> err_deltaP >> err_deltaP_stat >> err_deltaP_syst;
+	 >> deltaP >> err_deltaP >> err_deltaP_stat >> err_deltaP_syst >> err_deltaP_tot;
     
     AddScale(category, runMin, runMax, deltaP, err_deltaP_stat, err_deltaP_syst);
   }
   
   f_in.close();
-  
   return;
 }
 


### PR DESCRIPTION
Copies of electron scale corrector classes to be used in bare ROOT. 
Useful when embedded in free functions to correct the momentum on the fly. 
It uses the std EGMSmearer inputs and methods. 