### PR TITLE
Possibility to use new R9-more-granular electron scale corrections for Legacy2016 

### DIFF
--- a/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
+++ b/EgammaAnalysis/ElectronTools/src/EnergyScaleCorrection_class.cc
@@ -500,6 +500,19 @@ correctionCategory_class::correctionCategory_class(TString category_)
     //  std::cout << etmin << "\t" << etmax << "\t" << category.substr(p1 + 1, p2 - p1 - 1) << std::endl;
   }
   
+  // R9 region
+  p1 = category.find("-R9_");
+  p2 = p1 + 1;
+  if(p1 != std::string::npos) {
+    p1 = category.find("_", p1);
+    p2 = category.find("_", p1 + 1);
+    r9min = TString(category.substr(p1 + 1, p2 - p1 - 1)).Atof();
+    p1 = p2;
+    p2 = category.find("-", p1);
+    r9max = TString(category.substr(p1 + 1, p2 - p1 - 1)).Atof();
+    // std::cout << r9min << "\t" << r9max << "\t" << category.substr(p1 + 1, p2 - p1 - 1) << std::endl;
+  }
+
   if(category.find("gold")   != std::string::npos || 
      category.find("Gold")   != std::string::npos || 
      category.find("highR9") != std::string::npos) {

--- a/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/gen/GeneratorAnalyzer.py
@@ -143,7 +143,7 @@ class GeneratorAnalyzer( Analyzer ):
         for igp,gp in enumerate(good):
             gp.motherIndex = -1
             gp.sourceId    = 99
-            gp.promptHardFlag = gp.isPromptFinalState() or gp.isDirectPromptTauDecayProductFinalState() or gp.isHardProcess() 
+            gp.promptHardFlag = gp.isPromptFinalState() or gp.isDirectPromptTauDecayProductFinalState()
             gp.genSummaryIndex = igp
             (ancestor, ancestorKey) = (None,-1) if gp.numberOfMothers() == 0 else motherRef(gp)
             while ancestor:


### PR DESCRIPTION
- smearer code needs some additions to use the R9 granular categories
- in this PR, also add the removal of gp.isHardProcess() among the promptHard particles filtering that we did long time ago (but never committed)